### PR TITLE
Feat: Implement modal for adding bookmarks and fix delete icon underline

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,12 +14,29 @@
   <body>
     <main class="bookmarks-container" id="bookmarks-container">
       <div class="nav-container">
-        <nav class="add-btn" onclick="addLink()">Add</nav>
+        <nav class="add-btn" onclick="toggleBookmarkModal()">Add</nav>
         <nav class="snippets-btn" onclick="showSnippets()">Snippets</nav>
       </div>
       <div class="links-container" id="links-container">
         <!-- Bookmarks will be loaded here -->
       </div>
+    <div class="snippet-form" id="add-bookmark-modal" style="display: none;">
+      <h2 id="bookmark-form-title">Add New Bookmark</h2>
+      <form id="add-bookmark-form">
+        <div class="form-group">
+          <label for="bookmark-url">URL:</label>
+          <input type="url" id="bookmark-url" required />
+        </div>
+        <div class="form-group">
+          <label for="bookmark-name">Name:</label>
+          <input type="text" id="bookmark-name" required />
+        </div>
+        <div class="form-buttons">
+          <button type="submit" class="btn btn-primary">Save Bookmark</button>
+          <button type="button" class="btn btn-secondary" onclick="toggleBookmarkModal()">Cancel</button>
+        </div>
+      </form>
+    </div>
     </main>
 
     <div class="toast" id="toast">Bookmark saved!</div>

--- a/styles.css
+++ b/styles.css
@@ -310,3 +310,33 @@ code {
   word-wrap: normal;
   max-width: 100%;
 }
+
+/* Styles for the Add Bookmark Modal */
+#add-bookmark-modal {
+  /* Use snippet-form for base styling, but override/add for modal behavior */
+  position: fixed; /* Or absolute, depending on desired behavior relative to viewport or parent */
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 90%; /* Adjust width as needed, make it responsive */
+  max-width: 500px; /* Maximum width for larger screens */
+  z-index: 1001; /* Ensure it's above other content, like the nav's 100 */
+  /* display: none; is already set by inline style and .snippet-form, but good to keep in mind */
+}
+
+/* Optional: Add a backdrop for the modal */
+.modal-backdrop {
+  display: none; /* Hidden by default, shown when modal is active */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Semi-transparent black */
+  z-index: 1000; /* Below the modal, above other content */
+}
+
+/* Prevent underline on hover for specific delete bookmark button */
+.delete-bookmark-btn:hover {
+  text-decoration: none !important;
+}


### PR DESCRIPTION
Replaces the browser's prompt() for adding new bookmarks with a modal form. The new modal includes fields for URL and Name, and mirrors the styling of the snippets form.

Also fixes an issue where the '×' delete icon for bookmarks would get an underline on hover. This was resolved by adding a specific CSS class to the delete icon and applying `text-decoration: none !important;` on hover for that class.

Key changes:
- Added HTML structure for the bookmark modal in `index.html`.
- Updated `styles.css` to style the modal as a centered overlay and to prevent underlining on the delete icon.
- Modified `script.js`:
  - Added `toggleBookmarkModal()` to show/hide the new modal.
  - Added `handleAddBookmarkSubmit()` to handle bookmark creation via the modal, replacing the old `addLink()`'s prompt-based logic.
  - Attached event listener for the new form submission.
  - Added `delete-bookmark-btn` class to delete icons in `addLink` (now `handleAddBookmarkSubmit`) and `loadLinks` for CSS targeting.
  - Commented out the old `addLink()` function.